### PR TITLE
Add sort listings functionality

### DIFF
--- a/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
+++ b/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
@@ -63,11 +63,27 @@
   <div class="container my-4">
     <div id="gallery_title">Items Requested</div>
     <p>See what people are looking for here. Check out our FAQ for more.</p>
-    <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="table_toggle" oninput="updateQuery()">
-        <label class="form-check-label" for="table_toggle">
-            view as table
-        </label>
+    <div class="row justify-content-between" style="align-items: center; margin: 0px;">
+        <!-- Checkbox to view as table -->
+        <div class="form-check col-2">
+            <input class="form-check-input" type="checkbox" id="table_toggle" oninput="updateQuery()">
+            <label class="form-check-label" for="table_toggle">
+                view as table
+            </label>
+        </div>
+        <!-- Sorting options dropdown menu -->
+        <div class="dropdown show col-2">
+            <button class="btn btn-light dropdown-toggle px-3 hover-grey" style="font-weight: bold; border-color: #ced4da" type="button"
+              id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                sort by
+            </button>
+            <div class="dropdown-menu  dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+                <a class="dropdown-item" href="#">price: low to high</a>
+                <a class="dropdown-item" href="#">price: high to low</a>
+                <a class="dropdown-item" href="#">date posted: newest</a>
+                <a class="dropdown-item" href="#">date posted: oldest</a>
+            </div>
+        </div>
     </div>
     <hr>
   </div>

--- a/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
+++ b/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
@@ -21,7 +21,7 @@
               id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Post
             </button>
-            <div class="dropdown-menu  dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
               <div class="container-fluid dropdown-item mx-0 px-0">
                 <div class="row"> 
                   <button class="post-dropdown-item px-0 mx-0" style="border:none; background-color:transparent; outline:none;" data-bs-toggle="modal" data-bs-target="#post-dropdown-item">POST REQUEST</button>
@@ -77,7 +77,7 @@
               id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 sort by
             </button>
-            <div class="dropdown-menu  dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
                 <a class="dropdown-item" onClick="updateQuerySort('price_lowtohigh')">price: low to high</a>
                 <a class="dropdown-item" onClick="updateQuerySort('price_hightolow')">price: high to low</a>
                 <a class="dropdown-item" onClick="updateQuerySort('date_rectoold')">date posted: newest</a>

--- a/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
+++ b/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
@@ -78,10 +78,10 @@
                 sort by
             </button>
             <div class="dropdown-menu  dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-                <a class="dropdown-item" href="#">price: low to high</a>
-                <a class="dropdown-item" href="#">price: high to low</a>
-                <a class="dropdown-item" href="#">date posted: newest</a>
-                <a class="dropdown-item" href="#">date posted: oldest</a>
+                <a class="dropdown-item" href="{% url 'get_item_requests_relative' %}">price: low to high</a>
+                <a class="dropdown-item" href="{% url 'get_item_requests_relative' %}">price: high to low</a>
+                <a class="dropdown-item" href="{% url 'get_item_requests_relative' %}">date posted: newest</a>
+                <a class="dropdown-item" href="{% url 'get_item_requests_relative' %}">date posted: oldest</a>
             </div>
         </div>
     </div>
@@ -153,6 +153,7 @@
     let active_category_pks = [];
     let active_condition_indexes = [];
     let search_string = "";
+    let sort_type = "";
 
     let item_requests = [];        // continuously gathered item_requests, sorted by most relevant first
     // each item_request is a dict {"pk", "name", "price", "description", "lead_image", "album", etc.}

--- a/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
+++ b/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
@@ -193,15 +193,7 @@
     // sets sort_type based on current inputs, refresh listings
     function updateQuerySort(sort_type_input) {
       // update sort_type variable
-      if (sort_type_input == "price_hightolow") {
-          sort_type = "price_hightolow";
-      } else if (sort_type_input == "price_lowtohigh") {
-        sort_type = "price_lowtohigh";
-      } else if (sort_type_input == "date_oldtorec") {
-        sort_type = "date_oldtorec";
-      } else if (sort_type_input == "date_rectoold") {
-        sort_type = "date_rectoold";
-      }
+      sort_type = sort_type_input
 
       // refresh listings
       restart = true; // trigger a clear of the item_requests array, since query parameters have changed

--- a/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
+++ b/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
@@ -78,10 +78,10 @@
                 sort by
             </button>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-                <a class="dropdown-item" onClick="updateQuerySort('price_lowtohigh')">price: low to high</a>
-                <a class="dropdown-item" onClick="updateQuerySort('price_hightolow')">price: high to low</a>
-                <a class="dropdown-item" onClick="updateQuerySort('date_rectoold')">date posted: newest</a>
-                <a class="dropdown-item" onClick="updateQuerySort('date_oldtorec')">date posted: oldest</a>
+                <a class="dropdown-item btn" onClick="updateQuerySort('price_lowtohigh')">price: low to high</a>
+                <a class="dropdown-item btn" onClick="updateQuerySort('price_hightolow')">price: high to low</a>
+                <a class="dropdown-item btn" onClick="updateQuerySort('date_rectoold')">date posted: newest</a>
+                <a class="dropdown-item btn" onClick="updateQuerySort('date_oldtorec')">date posted: oldest</a>
             </div>
         </div>
     </div>

--- a/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
+++ b/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
@@ -78,10 +78,10 @@
                 sort by
             </button>
             <div class="dropdown-menu  dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-                <a class="dropdown-item" href="#">price: low to high</a>
-                <a class="dropdown-item" href="#">price: high to low</a>
-                <a class="dropdown-item" href="#">date posted: newest</a>
-                <a class="dropdown-item" href="#">date posted: oldest</a>
+                <a class="dropdown-item" onClick="updateQuerySort('price_lowtohigh')">price: low to high</a>
+                <a class="dropdown-item" onClick="updateQuerySort('price_hightolow')">price: high to low</a>
+                <a class="dropdown-item" onClick="updateQuerySort('date_rectoold')">date posted: newest</a>
+                <a class="dropdown-item" onClick="updateQuerySort('date_oldtorec')">date posted: oldest</a>
             </div>
         </div>
     </div>
@@ -162,9 +162,8 @@
     let restart = false;                // indicates that item_requests should be cleared
     let long_timer = null;
     
-
     // set active_category_pks, active_condition_indexes, search_string appropriately
-    // based on current inputs
+    // based on current inputs, refresh listings
     function updateQuery() {
         active_category_pks = [];
         active_condition_indexes = [];
@@ -189,6 +188,30 @@
           long_timer = null;
           window.setTimeout(() => {populateItemRequestsSynchronously(50, 200, 200000)}, 0);
         }
+    }
+
+    // sets sort_type based on current inputs, refresh listings
+    function updateQuerySort(sort_type_input) {
+      // update sort_type variable
+      if (sort_type_input == "price_hightolow") {
+          sort_type = "price_hightolow";
+      } else if (sort_type_input == "price_lowtohigh") {
+        sort_type = "price_lowtohigh";
+      } else if (sort_type_input == "date_oldtorec") {
+        sort_type = "date_oldtorec";
+      } else if (sort_type_input == "date_rectoold") {
+        sort_type = "date_rectoold";
+      }
+
+      // refresh listings
+      restart = true; // trigger a clear of the items array, since query parameters have changed
+      $('#restart_indicator').removeClass('hide');
+      
+      if (long_timer) {
+        window.clearTimeout(long_timer);
+        long_timer = null;
+        window.setTimeout(() => {populateItemsSynchronously(50, 200, 200000)}, 0);
+      }
     }
 
     // generates and injects new item_request HTML elements, updates 'last_rendered_item_request_index'
@@ -466,7 +489,7 @@
         if (item_requests.length != 0) {
             base_item_request_pk = item_requests[item_requests.length - 1]["pk"];
         }
-        fetch("/item_requests/get_relative/?count=" + count + "&direction=backward&base_item_request_pk=" + base_item_request_pk + "&search_string=" + search_string + "&condition_indexes=" + conditions_str + "&category_pks=" + categories_str)
+        fetch("/item_requests/get_relative/?count=" + count + "&direction=backward&base_item_request_pk=" + base_item_request_pk + "&search_string=" + search_string + "&condition_indexes=" + conditions_str + "&category_pks=" + categories_str + "&sort_type=" + sort_type)
             .then((resp) => {return resp.json();})
             .then((data) => {
 

--- a/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
+++ b/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
@@ -204,13 +204,13 @@
       }
 
       // refresh listings
-      restart = true; // trigger a clear of the items array, since query parameters have changed
+      restart = true; // trigger a clear of the item_requests array, since query parameters have changed
       $('#restart_indicator').removeClass('hide');
-      
+
       if (long_timer) {
         window.clearTimeout(long_timer);
         long_timer = null;
-        window.setTimeout(() => {populateItemsSynchronously(50, 200, 200000)}, 0);
+        window.setTimeout(() => {populateItemRequestsSynchronously(50, 200, 200000)}, 0);
       }
     }
 

--- a/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
+++ b/TRT-django/marketplace/templates/marketplace/browse_item_requests.html
@@ -78,10 +78,10 @@
                 sort by
             </button>
             <div class="dropdown-menu  dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-                <a class="dropdown-item" href="{% url 'get_item_requests_relative' %}">price: low to high</a>
-                <a class="dropdown-item" href="{% url 'get_item_requests_relative' %}">price: high to low</a>
-                <a class="dropdown-item" href="{% url 'get_item_requests_relative' %}">date posted: newest</a>
-                <a class="dropdown-item" href="{% url 'get_item_requests_relative' %}">date posted: oldest</a>
+                <a class="dropdown-item" href="#">price: low to high</a>
+                <a class="dropdown-item" href="#">price: high to low</a>
+                <a class="dropdown-item" href="#">date posted: newest</a>
+                <a class="dropdown-item" href="#">date posted: oldest</a>
             </div>
         </div>
     </div>

--- a/TRT-django/marketplace/templates/marketplace/gallery.html
+++ b/TRT-django/marketplace/templates/marketplace/gallery.html
@@ -71,7 +71,7 @@
             </label>
         </div>
         <div class="dropdown show col-2">
-            <button class="btn btn-light dropdown-toggle px-3 hover-grey" style="font-weight: bold;" type="button"
+            <button class="btn btn-light dropdown-toggle px-3 hover-grey" style="font-weight: bold; border-color: #ced4da" type="button"
               id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 sort by
             </button>

--- a/TRT-django/marketplace/templates/marketplace/gallery.html
+++ b/TRT-django/marketplace/templates/marketplace/gallery.html
@@ -63,23 +63,25 @@
   <div class="container my-4">
     <div id="gallery_title">Items for Sale</div>
     <p>Purchase items here. Check out our FAQ for more.</p>
-    <div class="form-check">
-        <input class="form-check-input" type="checkbox" id="table_toggle" oninput="updateQuery()">
-        <label class="form-check-label" for="table_toggle">
-            view as table
-        </label>
-    </div>
-    <div class="dropdown show">
-        <button class="btn btn-light dropdown-toggle px-3 hover-grey" style="font-weight: bold;" type="button"
-          id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            sort by
-        </button>
-        <div class="dropdown-menu  dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-            <a class="dropdown-item" href="#">price: low to high</a>
-            <a class="dropdown-item" href="#">price: high to low</a>
-            <a class="dropdown-item" href="#">date posted: newest</a>
-            <a class="dropdown-item" href="#">date posted: oldest</a>
-      </div>
+    <div class="row justify-content-between" style="margin: 0px;">
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="table_toggle" oninput="updateQuery()">
+            <label class="form-check-label" for="table_toggle">
+                view as table
+            </label>
+        </div>
+        <div class="dropdown show">
+            <button class="btn btn-light dropdown-toggle px-3 hover-grey" style="font-weight: bold;" type="button"
+              id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                sort by
+            </button>
+            <div class="dropdown-menu  dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+                <a class="dropdown-item" href="#">price: low to high</a>
+                <a class="dropdown-item" href="#">price: high to low</a>
+                <a class="dropdown-item" href="#">date posted: newest</a>
+                <a class="dropdown-item" href="#">date posted: oldest</a>
+            </div>
+        </div>
     </div>
     <hr>
   </div>

--- a/TRT-django/marketplace/templates/marketplace/gallery.html
+++ b/TRT-django/marketplace/templates/marketplace/gallery.html
@@ -64,12 +64,14 @@
     <div id="gallery_title">Items for Sale</div>
     <p>Purchase items here. Check out our FAQ for more.</p>
     <div class="row justify-content-between" style="align-items: center; margin: 0px;">
+        <!-- Checkbox to view as table -->
         <div class="form-check col-2">
             <input class="form-check-input" type="checkbox" id="table_toggle" oninput="updateQuery()">
             <label class="form-check-label" for="table_toggle">
                 view as table
             </label>
         </div>
+        <!-- Sorting options dropdown menu -->
         <div class="dropdown show col-2">
             <button class="btn btn-light dropdown-toggle px-3 hover-grey" style="font-weight: bold; border-color: #ced4da" type="button"
               id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">

--- a/TRT-django/marketplace/templates/marketplace/gallery.html
+++ b/TRT-django/marketplace/templates/marketplace/gallery.html
@@ -70,10 +70,16 @@
         </label>
     </div>
     <div class="dropdown show">
-      <button class="btn btn-light dropdown-toggle px-3 hover-grey" style="font-weight: bold;" type="button"
-        id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-        sort by
-      </button>
+        <button class="btn btn-light dropdown-toggle px-3 hover-grey" style="font-weight: bold;" type="button"
+          id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            sort by
+        </button>
+        <div class="dropdown-menu  dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+            <a class="dropdown-item" href="#">price: low to high</a>
+            <a class="dropdown-item" href="#">price: high to low</a>
+            <a class="dropdown-item" href="#">date posted: newest</a>
+            <a class="dropdown-item" href="#">date posted: oldest</a>
+      </div>
     </div>
     <hr>
   </div>

--- a/TRT-django/marketplace/templates/marketplace/gallery.html
+++ b/TRT-django/marketplace/templates/marketplace/gallery.html
@@ -78,10 +78,10 @@
                 sort by
             </button>
             <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-                <a class="dropdown-item" onClick="updateQuerySort('price_lowtohigh')">price: low to high</a>
-                <a class="dropdown-item" onClick="updateQuerySort('price_hightolow')">price: high to low</a>
-                <a class="dropdown-item" onClick="updateQuerySort('date_rectoold')">date posted: newest</a>
-                <a class="dropdown-item" onClick="updateQuerySort('date_oldtorec')">date posted: oldest</a>
+                <a class="dropdown-item btn" onClick="updateQuerySort('price_lowtohigh')">price: low to high</a>
+                <a class="dropdown-item btn" onClick="updateQuerySort('price_hightolow')">price: high to low</a>
+                <a class="dropdown-item btn" onClick="updateQuerySort('date_rectoold')">date posted: newest</a>
+                <a class="dropdown-item btn" onClick="updateQuerySort('date_oldtorec')">date posted: oldest</a>
             </div>
         </div>
     </div>

--- a/TRT-django/marketplace/templates/marketplace/gallery.html
+++ b/TRT-django/marketplace/templates/marketplace/gallery.html
@@ -78,10 +78,10 @@
                 sort by
             </button>
             <div class="dropdown-menu  dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-                <a class="dropdown-item" href="#">price: low to high</a>
-                <a class="dropdown-item" href="#">price: high to low</a>
-                <a class="dropdown-item" href="#">date posted: newest</a>
-                <a class="dropdown-item" href="#">date posted: oldest</a>
+                <a class="dropdown-item" onClick="updateQuerySort('price_lowtohigh')">price: low to high</a>
+                <a class="dropdown-item" onClick="updateQuerySort('price_hightolow')">price: high to low</a>
+                <a class="dropdown-item" onClick="updateQuerySort('date_rectoold')">date posted: newest</a>
+                <a class="dropdown-item" onClick="updateQuerySort('date_oldtorec')">date posted: oldest</a>
             </div>
         </div>
     </div>
@@ -153,6 +153,7 @@
     let active_category_pks = [];
     let active_condition_indexes = [];
     let search_string = "";
+    let sort_type = "";
 
     let items = [];        // continuously gathered items, sorted by most relevant first
     // each item is a dict {"pk", "name", "price", "description", "lead_image", "album", etc.}
@@ -166,7 +167,7 @@
 
 
     // set active_category_pks, active_condition_indexes, search_string appropriately
-    // based on current inputs
+    // based on current inputs, refresh listings
     function updateQuery() {
         active_category_pks = [];
         active_condition_indexes = [];
@@ -191,6 +192,29 @@
           long_timer = null;
           window.setTimeout(() => {populateItemsSynchronously(50, 200, 200000)}, 0);
         }
+    }
+
+    // sets sort_type based on current inputs, refresh listings
+    function updateQuerySort(sort_type_input) {
+      // update sort_type variable
+      if (sort_type_input == "price_hightolow") {
+          sort_type = "price_hightolow";
+      } else if (sort_type_input == "price_lowtohigh") {
+        sort_type = "price_lowtohigh";
+      } else if (sort_type_input == "date_oldtorec") {
+        sort_type = "date_oldtorec";
+      } else if (sort_type_input == "date_rectoold") {
+        sort_type = "date_rectoold";
+      }
+
+      // refresh listings
+      restart = true; // trigger a clear of the items array, since query parameters have changed
+      $('#restart_indicator').removeClass('hide');
+      if (long_timer) {
+        window.clearTimeout(long_timer);
+        long_timer = null;
+        window.setTimeout(() => {populateItemsSynchronously(50, 200, 200000)}, 0);
+      }
     }
 
     // generates and injects new item HTML elements, updates 'last_rendered_item_index'
@@ -495,7 +519,7 @@
         if (items.length != 0) {
             base_item_pk = items[items.length - 1]["pk"];
         }
-        fetch("/items/get_relative/?count=" + count + "&direction=backward&base_item_pk=" + base_item_pk + "&search_string=" + search_string + "&condition_indexes=" + conditions_str + "&category_pks=" + categories_str)
+        fetch("/items/get_relative/?count=" + count + "&direction=backward&base_item_pk=" + base_item_pk + "&search_string=" + search_string + "&condition_indexes=" + conditions_str + "&category_pks=" + categories_str + "&sort_type=" + sort_type)
             .then((resp) => {return resp.json();})
             .then((data) => {
 

--- a/TRT-django/marketplace/templates/marketplace/gallery.html
+++ b/TRT-django/marketplace/templates/marketplace/gallery.html
@@ -197,15 +197,7 @@
     // sets sort_type based on current inputs, refresh listings
     function updateQuerySort(sort_type_input) {
       // update sort_type variable
-      if (sort_type_input == "price_hightolow") {
-          sort_type = "price_hightolow";
-      } else if (sort_type_input == "price_lowtohigh") {
-        sort_type = "price_lowtohigh";
-      } else if (sort_type_input == "date_oldtorec") {
-        sort_type = "date_oldtorec";
-      } else if (sort_type_input == "date_rectoold") {
-        sort_type = "date_rectoold";
-      }
+      sort_type = sort_type_input
 
       // refresh listings
       restart = true; // trigger a clear of the items array, since query parameters have changed

--- a/TRT-django/marketplace/templates/marketplace/gallery.html
+++ b/TRT-django/marketplace/templates/marketplace/gallery.html
@@ -69,6 +69,12 @@
             view as table
         </label>
     </div>
+    <div class="dropdown show">
+      <button class="btn btn-light dropdown-toggle px-3 hover-grey" style="font-weight: bold;" type="button"
+        id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+        sort by
+      </button>
+    </div>
     <hr>
   </div>
 

--- a/TRT-django/marketplace/templates/marketplace/gallery.html
+++ b/TRT-django/marketplace/templates/marketplace/gallery.html
@@ -63,14 +63,14 @@
   <div class="container my-4">
     <div id="gallery_title">Items for Sale</div>
     <p>Purchase items here. Check out our FAQ for more.</p>
-    <div class="row justify-content-between" style="margin: 0px;">
-        <div class="form-check">
+    <div class="row justify-content-between" style="align-items: center; margin: 0px;">
+        <div class="form-check col-2">
             <input class="form-check-input" type="checkbox" id="table_toggle" oninput="updateQuery()">
             <label class="form-check-label" for="table_toggle">
                 view as table
             </label>
         </div>
-        <div class="dropdown show">
+        <div class="dropdown show col-2">
             <button class="btn btn-light dropdown-toggle px-3 hover-grey" style="font-weight: bold;" type="button"
               id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 sort by

--- a/TRT-django/marketplace/templates/marketplace/gallery.html
+++ b/TRT-django/marketplace/templates/marketplace/gallery.html
@@ -21,7 +21,7 @@
               id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
               Post
             </button>
-            <div class="dropdown-menu  dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
               <div class="container-fluid dropdown-item mx-0 px-0">
                 <div class="row"> 
                   <button class="post-dropdown-item px-0 mx-0" style="border:none; background-color:transparent; outline:none;" data-bs-toggle="modal" data-bs-target="#post-dropdown-item">POST ITEM</button>
@@ -77,7 +77,7 @@
               id="dropdownMenuButton" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 sort by
             </button>
-            <div class="dropdown-menu  dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+            <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
                 <a class="dropdown-item" onClick="updateQuerySort('price_lowtohigh')">price: low to high</a>
                 <a class="dropdown-item" onClick="updateQuerySort('price_hightolow')">price: high to low</a>
                 <a class="dropdown-item" onClick="updateQuerySort('date_rectoold')">date posted: newest</a>

--- a/TRT-django/marketplace/views.py
+++ b/TRT-django/marketplace/views.py
@@ -467,7 +467,6 @@ def getItemsRelative(request):
         items = Item.objects.filter(pk__in=items) # get rid of duplicate rows (can happen because of filtering on m2m categories table)
 
     # sort items by price or date if requested
-
     if "sort_type" in request.GET:
         sort_type = request.GET["sort_type"]
     
@@ -1629,7 +1628,10 @@ def getItemRequestsRelative(request):
         item_requests = ItemRequest.objects.filter(pk__in=item_requests) # get rid of duplicate rows (can happen because of filtering on m2m categories table)
 
     # sort items by price or date if requested
-    if "sortbyprice_hightolow" in request.GET:
+    if "sort_type" in request.GET:
+        sort_type = request.GET["sort_type"]
+    
+    if sort_type == "price_hightolow":
         item_requests = item_requests.annotate(
             row=Window(
                 expression=RowNumber(),
@@ -1637,7 +1639,7 @@ def getItemRequestsRelative(request):
             )
         )
 
-    elif "sortbyprice_lowtohigh" in request.GET:
+    elif sort_type == "sortbyprice_lowtohigh":
         item_requests = item_requests.annotate(
             row=Window(
                 expression=RowNumber(),
@@ -1645,7 +1647,7 @@ def getItemRequestsRelative(request):
             )
         )
 
-    elif "sortbydate_oldtorec" in request.GET:
+    elif sort_type == "sortbydate_oldtorec":
         item_requests = item_requests.annotate(
             row=Window(
                 expression=RowNumber(),
@@ -1653,7 +1655,7 @@ def getItemRequestsRelative(request):
             )
         )
 
-    elif "sortbydate_rectoold" in request.GET:
+    elif sort_type == "sortbydate_rectoold":
         item_requests = item_requests.annotate(
             row=Window(
                 expression=RowNumber(),

--- a/TRT-django/marketplace/views.py
+++ b/TRT-django/marketplace/views.py
@@ -474,7 +474,7 @@ def getItemsRelative(request):
         items = items.annotate(
             row=Window(
                 expression=RowNumber(),
-                order_by=[F("price").desc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
+                order_by=[F("price").asc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
             )
         )
 
@@ -482,7 +482,7 @@ def getItemsRelative(request):
         items = items.annotate(
             row=Window(
                 expression=RowNumber(),
-                order_by=[F("price").asc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
+                order_by=[F("price").desc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
             )
         )
 
@@ -490,7 +490,7 @@ def getItemsRelative(request):
         items = items.annotate(
             row=Window(
                 expression=RowNumber(),
-                order_by=[F("posted_date").asc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
+                order_by=[F("posted_date").desc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
             )
         )
 
@@ -498,7 +498,7 @@ def getItemsRelative(request):
         items = items.annotate(
             row=Window(
                 expression=RowNumber(),
-                order_by=[F("posted_date").desc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
+                order_by=[F("posted_date").asc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
             )
         )
 

--- a/TRT-django/marketplace/views.py
+++ b/TRT-django/marketplace/views.py
@@ -467,9 +467,11 @@ def getItemsRelative(request):
         items = Item.objects.filter(pk__in=items) # get rid of duplicate rows (can happen because of filtering on m2m categories table)
 
     # sort items by price or date if requested
+
+    if "sort_type" in request.GET:
+        sort_type = request.GET["sort_type"]
     
-    # if "sortbyprice_hightolow" in request.GET:
-    if sort_type == "sortbyprice_hightolow":
+    if sort_type == "price_hightolow":
         items = items.annotate(
             row=Window(
                 expression=RowNumber(),
@@ -477,7 +479,7 @@ def getItemsRelative(request):
             )
         )
 
-    elif "sortbyprice_lowtohigh" in request.GET:
+    elif sort_type == "price_lowtohigh":
         items = items.annotate(
             row=Window(
                 expression=RowNumber(),
@@ -485,7 +487,7 @@ def getItemsRelative(request):
             )
         )
 
-    elif "sortbydate_oldtorec" in request.GET:
+    elif sort_type == "date_oldtorec":
         items = items.annotate(
             row=Window(
                 expression=RowNumber(),
@@ -493,7 +495,7 @@ def getItemsRelative(request):
             )
         )
 
-    elif "sortbydate_rectoold" in request.GET:
+    elif sort_type == "date_rectoold":
         items = items.annotate(
             row=Window(
                 expression=RowNumber(),

--- a/TRT-django/marketplace/views.py
+++ b/TRT-django/marketplace/views.py
@@ -1635,31 +1635,31 @@ def getItemRequestsRelative(request):
         item_requests = item_requests.annotate(
             row=Window(
                 expression=RowNumber(),
-                order_by=[F("price").desc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
-            )
-        )
-
-    elif sort_type == "sortbyprice_lowtohigh":
-        item_requests = item_requests.annotate(
-            row=Window(
-                expression=RowNumber(),
                 order_by=[F("price").asc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
             )
         )
 
-    elif sort_type == "sortbydate_oldtorec":
+    elif sort_type == "price_lowtohigh":
         item_requests = item_requests.annotate(
             row=Window(
                 expression=RowNumber(),
-                order_by=[F("posted_date").asc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
+                order_by=[F("price").desc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
             )
         )
 
-    elif sort_type == "sortbydate_rectoold":
+    elif sort_type == "date_oldtorec":
         item_requests = item_requests.annotate(
             row=Window(
                 expression=RowNumber(),
                 order_by=[F("posted_date").desc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
+            )
+        )
+
+    elif sort_type == "date_rectoold":
+        item_requests = item_requests.annotate(
+            row=Window(
+                expression=RowNumber(),
+                order_by=[F("posted_date").asc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
             )
         )
 

--- a/TRT-django/marketplace/views.py
+++ b/TRT-django/marketplace/views.py
@@ -439,6 +439,7 @@ def getItemsRelative(request):
     search_string = ""
     condition_indexes = []
     categories = []
+    sort_type = ""
 
     if "search_string" in request.GET:
         search_string = request.GET["search_string"]
@@ -465,8 +466,18 @@ def getItemsRelative(request):
         items = items.filter(categories__in=categories)
         items = Item.objects.filter(pk__in=items) # get rid of duplicate rows (can happen because of filtering on m2m categories table)
 
+    if "sort_type" in request.GET:
+        try:
+            sort_type = request.GET["sort_type"]
+            print("/////HELLO 1//////")
+        except:
+            print("hello 2")
+            return HttpResponse(status=400)
+
     # sort items by price or date if requested
-    if "sortbyprice_hightolow" in request.GET:
+    
+    # if "sortbyprice_hightolow" in request.GET:
+    if sort_type == "sortbyprice_hightolow":
         items = items.annotate(
             row=Window(
                 expression=RowNumber(),
@@ -1596,6 +1607,7 @@ def getItemRequestsRelative(request):
     search_string = ""
     condition_indexes = []
     categories = []
+    sort_type = ""
 
     if "search_string" in request.GET:
         search_string = request.GET["search_string"]
@@ -1623,7 +1635,20 @@ def getItemRequestsRelative(request):
         item_requests = ItemRequest.objects.filter(pk__in=item_requests) # get rid of duplicate rows (can happen because of filtering on m2m categories table)
 
     # sort items by price or date if requested
+    
+    if "sort_type" in request.GET:
+        try:
+            sort_type = request.GET["sort_type"]
+            print("/////HELLO 1//////")
+        except:
+            print("hello 2")
+            return HttpResponse(status=400)
+
+    # sort items by price or date if requested
+    
     if "sortbyprice_hightolow" in request.GET:
+    # if sort_type == "sortbyprice_hightolow":
+    # if "sortbyprice_hightolow" in request.GET:
         item_requests = item_requests.annotate(
             row=Window(
                 expression=RowNumber(),

--- a/TRT-django/marketplace/views.py
+++ b/TRT-django/marketplace/views.py
@@ -536,44 +536,29 @@ def getItemsRelative(request):
         items = Item.objects.filter(pk__in=items) # get rid of duplicate rows (can happen because of filtering on m2m categories table)
 
     # sort items by price or date if requested
+    order_by = ""
     if "sort_type" in request.GET:
         sort_type = request.GET["sort_type"]
 
-#    items = sortMyItems(sort_type, items)
+        # items = sortMyItems(sort_type, items)
 
+        if sort_type == "price_hightolow":
+            order_by = [F("price").asc(), F("pk").asc()]
+        elif sort_type == "price_lowtohigh":
+            order_by=[F("price").desc(), F("pk").asc()]
+        elif sort_type == "date_oldtorec":
+            order_by=[F("posted_date").desc(), F("pk").asc()]
+        elif sort_type == "date_rectoold":
+            order_by=[F("posted_date").asc(), F("pk").asc()]
+
+    if order_by != "":
+        items = items.annotate(
+            row=Window(
+                expression=RowNumber(),
+                order_by=order_by, 
+            )
+        )
     
-    if sort_type == "price_hightolow":
-        items = items.annotate(
-            row=Window(
-                expression=RowNumber(),
-                order_by=[F("price").asc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
-            )
-        )
-
-    elif sort_type == "price_lowtohigh":
-        items = items.annotate(
-            row=Window(
-                expression=RowNumber(),
-                order_by=[F("price").desc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
-            )
-        )
-
-    elif sort_type == "date_oldtorec":
-        items = items.annotate(
-            row=Window(
-                expression=RowNumber(),
-                order_by=[F("posted_date").desc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
-            )
-        )
-
-    elif sort_type == "date_rectoold":
-        items = items.annotate(
-            row=Window(
-                expression=RowNumber(),
-                order_by=[F("posted_date").asc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
-            )
-        )
-
     # default sort
     else:
         # annotate items by search string rank
@@ -586,7 +571,6 @@ def getItemsRelative(request):
                 order_by=[F("rank").asc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
             )
         )
-
 
     # get the correct slice of items
     if base_item_pk == -1:
@@ -1701,38 +1685,27 @@ def getItemRequestsRelative(request):
         item_requests = ItemRequest.objects.filter(pk__in=item_requests) # get rid of duplicate rows (can happen because of filtering on m2m categories table)
 
     # sort items by price or date if requested
+    # sort items by price or date if requested
+    order_by = ""
     if "sort_type" in request.GET:
         sort_type = request.GET["sort_type"]
-    
-    if sort_type == "price_hightolow":
-        item_requests = item_requests.annotate(
-            row=Window(
-                expression=RowNumber(),
-                order_by=[F("price").asc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
-            )
-        )
 
-    elif sort_type == "price_lowtohigh":
-        item_requests = item_requests.annotate(
-            row=Window(
-                expression=RowNumber(),
-                order_by=[F("price").desc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
-            )
-        )
+        # items = sortMyItems(sort_type, items)
 
-    elif sort_type == "date_oldtorec":
-        item_requests = item_requests.annotate(
-            row=Window(
-                expression=RowNumber(),
-                order_by=[F("posted_date").desc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
-            )
-        )
+        if sort_type == "price_hightolow":
+            order_by = [F("price").asc(), F("pk").asc()]
+        elif sort_type == "price_lowtohigh":
+            order_by=[F("price").desc(), F("pk").asc()]
+        elif sort_type == "date_oldtorec":
+            order_by=[F("posted_date").desc(), F("pk").asc()]
+        elif sort_type == "date_rectoold":
+            order_by=[F("posted_date").asc(), F("pk").asc()]
 
-    elif sort_type == "date_rectoold":
+    if order_by != "":
         item_requests = item_requests.annotate(
             row=Window(
                 expression=RowNumber(),
-                order_by=[F("posted_date").asc(), F("pk").asc()], # also order by unique pk to make tie-breaks consistent
+                order_by=order_by, 
             )
         )
 

--- a/TRT-django/marketplace/views.py
+++ b/TRT-django/marketplace/views.py
@@ -466,14 +466,6 @@ def getItemsRelative(request):
         items = items.filter(categories__in=categories)
         items = Item.objects.filter(pk__in=items) # get rid of duplicate rows (can happen because of filtering on m2m categories table)
 
-    if "sort_type" in request.GET:
-        try:
-            sort_type = request.GET["sort_type"]
-            print("/////HELLO 1//////")
-        except:
-            print("hello 2")
-            return HttpResponse(status=400)
-
     # sort items by price or date if requested
     
     # if "sortbyprice_hightolow" in request.GET:
@@ -1635,20 +1627,7 @@ def getItemRequestsRelative(request):
         item_requests = ItemRequest.objects.filter(pk__in=item_requests) # get rid of duplicate rows (can happen because of filtering on m2m categories table)
 
     # sort items by price or date if requested
-    
-    if "sort_type" in request.GET:
-        try:
-            sort_type = request.GET["sort_type"]
-            print("/////HELLO 1//////")
-        except:
-            print("hello 2")
-            return HttpResponse(status=400)
-
-    # sort items by price or date if requested
-    
     if "sortbyprice_hightolow" in request.GET:
-    # if sort_type == "sortbyprice_hightolow":
-    # if "sortbyprice_hightolow" in request.GET:
         item_requests = item_requests.annotate(
             row=Window(
                 expression=RowNumber(),


### PR DESCRIPTION
Working with @ysl-ee to add sorting dropdown to "Items Requested" and "Items for Sale" gallery pages. (Taylor on frontend, Youngseo on backend)

Example demos: 

1. On the "Items Requested" page, user selects "price: low to high":
<img width="600" alt="Screen Shot 2023-03-21 at 12 13 56 PM" src="https://user-images.githubusercontent.com/80173363/226672175-bb407a6f-f523-4358-a4dc-e21752723f3f.png">

Result:
<img width="600" alt="Screen Shot 2023-03-21 at 12 14 12 PM" src="https://user-images.githubusercontent.com/80173363/226672889-fc1f3a54-5269-45dd-b90c-4b7f1bff84de.png">

2. On the "Items for Sale" page,  user selects "date posted: newest":
<img width="600" alt="Screen Shot 2023-03-21 at 12 15 29 PM" src="https://user-images.githubusercontent.com/80173363/226673618-5609e358-fe91-45e3-8cc6-13d2817b6a6d.png">

Result:
<img width="600" alt="Screen Shot 2023-03-21 at 12 15 40 PM" src="https://user-images.githubusercontent.com/80173363/226673669-53e20524-2833-44c6-a96e-691ea0f8a4d6.png">
